### PR TITLE
Allow a version to be specified

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        channel: [stable, beta, dev]
+        channel: [stable, stable@2.7.2, beta, dev]
     steps:
       - uses: actions/checkout@v2
       - uses: ./

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -10,6 +10,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         channel: [stable, stable@2.7.2, beta, dev]

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -13,7 +13,24 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        channel: [stable, stable@2.7.2, beta, dev]
+        sdk: [stable, 2.7.2, 2.12.0-133.7.beta, beta, dev ]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        with:
+          sdk: ${{ matrix.sdk }}
+
+      - name: Run hello world
+        run: |
+          echo "main() { print('hello world'); }" > hello.dart
+          dart hello.dart
+
+  test_deprecated_channel:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        channel: [ stable ]
     steps:
       - uses: actions/checkout@v2
       - uses: ./

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## Initial version
+## 0.2
+
+- Deprecate `channel` input, replaced by `sdk` input
+- The `sdk` input accepts either a channel _(which infers `latest` as the version)_, or a specific version string from any of the three release channels.
+  > See [Matrix Testing](./README.md#matrix-testing) for an example. 
+
+## Initial version (0.1)
 
 - Basic download and setup.
 - Support for Linux, macOS, and Windows.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,42 @@ jobs:
         run: dart test
 ```
 
+## Specifying a stable version
+
+By default, the `latest` release is used that has been published within the specified `channel`.
+
+If you want to test on a previous release from the `stable` channel, you can specify it following an `@` 
+delimiter as shown below:
+
+```
+name: Dart
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        channel: [stable, stable@2.7.2]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dart-lang/setup-dart@v1
+        with:
+          channel: ${{ matrix.channel }}
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Run tests
+        run: dart test
+```
+
 # License
 
 See the [`LICENSE`](LICENSE) file.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ jobs:
         run: pub run test
 ```
 
+> __NOTE:__ The above example is using the deprecated global `pub` executable instead of `dart pub` - which was released in `2.12.0`.
+> 
+> When specifying a version that precedes the `2.12.0` release _(like `2.7.2` from the above example)_ - the commands need to work across all versions in the matrix.
+> 
+> If you are not testing version(s) that precede the `2.12.0` release, use `dart pub get` / `dart test` instead of `pub get` / `pub run test`.
+
 # License
 
 See the [`LICENSE`](LICENSE) file.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
       - uses: dart-lang/setup-dart@v1
 
       - name: Install dependencies
-        run: dart pub get
+        run: dart pub get~~~~
 
       - name: Hello world
         run: dart bin/hello_world.dart
@@ -67,7 +67,7 @@ Various static checks:
 Double matrix across two dimensions:
 
   - All three major operating systems: Linux, macOS, and Windows.
-  - Dart release channels: stable, beta, dev.
+  - Dart SDK: stable, beta, dev, or a specific version string.
 
 ```
 name: Dart
@@ -84,54 +84,18 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        channel: [stable, beta, dev]
+        sdk: [stable, 2.7.2, 2.12.0-1.4.beta, beta, dev]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1
         with:
-          channel: ${{ matrix.channel }}
+          sdk: ${{ matrix.sdk }}
 
       - name: Install dependencies
-        run: dart pub get
+        run: pub get
 
       - name: Run tests
-        run: dart test
-```
-
-## Specifying a stable version
-
-By default, the `latest` release is used that has been published within the specified `channel`.
-
-If you want to test on a previous release from the `stable` channel, you can specify it following an `@` 
-delimiter as shown below:
-
-```
-name: Dart
-
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-
-jobs:
-  test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        channel: [stable, stable@2.7.2]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1
-        with:
-          channel: ${{ matrix.channel }}
-
-      - name: Install dependencies
-        run: dart pub get
-
-      - name: Run tests
-        run: dart test
+        run: pub run test
 ```
 
 # License

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
       - uses: dart-lang/setup-dart@v1
 
       - name: Install dependencies
-        run: dart pub get~~~~
+        run: dart pub get
 
       - name: Hello world
         run: dart bin/hello_world.dart
@@ -42,7 +42,7 @@ jobs:
 Various static checks:
 
   1) Check static analysis with the Dart analyzer
-  2) Check code follows Dart ideomatic formatting
+  2) Check code follows Dart idiomatic formatting
   3) Check that unit tests pass
 
 ```

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: "Setup Dart SDK"
 description: "Setup the Dart SDK, and add it to the PATH"
 inputs:
   channel:
-    description: "The release channel to install from ('stable', 'beta', or 'dev')"
+    description: "The release channel to install from ('stable', 'stable@version', 'beta', or 'dev')"
     required: false
     default: "stable"
 runs:

--- a/action.yml
+++ b/action.yml
@@ -1,12 +1,18 @@
 name: "Setup Dart SDK"
 description: "Setup the Dart SDK, and add it to the PATH"
 inputs:
+  # @deprecated - Use sdk instead.
   channel:
-    description: "The release channel to install from ('stable', 'stable@version', 'beta', or 'dev')"
+    description: "The release channel to install from ('stable', 'beta', or 'dev'). DEPRECATED. Use sdk instead."
+    required: false
+    # none is used only to assert whether the consumer has stopped using this deprecated input.
+    default: "none"
+  sdk:
+    description: "The channel, or a specific version from a channel to install ('stable', 'beta', 'dev', '2.7.2', '2.12.0-1.4.beta'). Using one of the three channels instead of a version will give you the latest version published to that channel."
     required: false
     default: "stable"
 runs:
   using: "composite"
   steps:
-    - run: $GITHUB_ACTION_PATH/setup.sh ${{ inputs.channel }} ${{ runner.os }}
+    - run: $GITHUB_ACTION_PATH/setup.sh ${{ inputs.sdk }} ${{ inputs.channel }} ${{ runner.os }}
       shell: bash

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@
 ###############################################################################
 # Bash script that downloads and does setup for a Dart SDK.                   #
 # Takes three params; first listed is the default:                            #
-# $1: Dart channel: stable|beta|dev                                           #
+# $1: Dart channel: stable<@version>|beta<@version>|dev<@version>             #
 # $2: OS: Linux|Windows|macOS                                                 #
 # $3: ARCH: x64|ia32                                                          #
 ###############################################################################
@@ -11,15 +11,23 @@
 
 # Parse args.
 CHANNEL="${1:-stable}"
-OS="${2:-Linux}"
-ARCH="${3:-x64}"
+VERSION=$(echo $CHANNEL | cut -s -d'@' -f 2)
+if [[ ! "$VERSION" ]]
+then
+  VERSION=latest
+else
+  # A version was specified, but the channel should just be the first part before the version delimiter
+  CHANNEL=$(echo $CHANNEL | cut -s -d'@' -f 1)
+fi
+OS="${3:-Linux}"
+ARCH="${4:-x64}"
 OS=$(echo "$OS" | awk '{print tolower($0)}')
-echo "Installing Dart SDK from the ${CHANNEL} channel on ${OS}-${ARCH}"
+echo "Installing Dart SDK version \"${VERSION}\" from the ${CHANNEL} channel on ${OS}-${ARCH}"
 
 # Calculate download Url. Based on:
 # https://dart.dev/tools/sdk/archive#download-urls
 PREFIX="https://storage.googleapis.com/dart-archive/channels"
-URL="${PREFIX}/${CHANNEL}/release/latest/sdk/dartsdk-${OS}-${ARCH}-release.zip"
+URL="${PREFIX}/${CHANNEL}/release/${VERSION}/sdk/dartsdk-${OS}-${ARCH}-release.zip"
 echo "Downloading ${URL}..."
 
 # Download installation zip.

--- a/setup.sh
+++ b/setup.sh
@@ -19,8 +19,8 @@ else
   # A version was specified, but the channel should just be the first part before the version delimiter
   CHANNEL=$(echo $CHANNEL | cut -s -d'@' -f 1)
 fi
-OS="${3:-Linux}"
-ARCH="${4:-x64}"
+OS="${2:-Linux}"
+ARCH="${3:-x64}"
 OS=$(echo "$OS" | awk '{print tolower($0)}')
 echo "Installing Dart SDK version \"${VERSION}\" from the ${CHANNEL} channel on ${OS}-${ARCH}"
 


### PR DESCRIPTION
Hi there!

We recently migrated CI for some OSS repos at Workiva to Github actions. However, the system we were migrating from (Travis) allowed us to specify a specific version of dart - instead of just assuming `latest` from a given channel as this action currently does.

We are [using a local action right now](https://github.com/Workiva/over_react/pull/657/checks?check_run_id=1703697177) that allows a specific version - but I think it would be a useful feature for the community-at-large to use as well - as suggested in #3.

The feature I'm proposing - is to add an `sdk` input that allows

```
some.version.string
some.version.string.beta
some.version.string.dev
```

in addition to the existing support for inferring "latest" from `stable`, `dev` and `beta` channels.

This change deprecates the use of the `channel` input.

I've added a section to the README with explanation, and updated the example action as well.

The only caveat I've found is that running

```
dart pub <pub_command>
```

fails on the matrix job when a version is specified. However, just running `pub <pub_command>` does not fail - so we've adjusted our config to remove `dart` from our `pub` commands. I could not figure out why this difference exists - as all the executable paths within `${RUNNER_TOOL_CACHE}/dart-sdk/bin` look identical to the matrix job that uses `latest`. If I've missed something obvious that needs to be adjusted, please let me know.

Also, #3 suggests adding a `version` input in-addition-to the `channel` input. The trouble I found with doing it that way - was that the matrix ballooned.

e.g. if you were to want to test both stable latest and stable 2.7.2 - specifying it using two inputs like so:

```
channel: [stable, stable]
version: [latest, 2.7.2]
```

causes the matrix of jobs to be:

```
stable (latest)
stable (2.7.2)
stable (latest)
stable (2.7.2)
```

Obviously - you could do 

```
channel: [stable]
version: [latest, 2.7.2]
```

which would work as expected - but if the consumer wanted to test two versions of stable and the latest version of dev, or a specific version of stable and a specific version of the dev channel - it seems the way matrix works in gh actions wouldn't be a good fit.

I couldn’t figure out a way around that - which is why I opted for a single `sdk` input instead.

Thanks for your time and consideration @mit-mit and @kevmoo!
