### PR TITLE
Add a way to setup raw builds for all channels

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -13,9 +13,31 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        # Test latest stable, beta, dev channels + last stable release
+        # prior to the introduction of the unified `dart` developer tool.
+        sdk: [stable, beta, dev, 2.9.3, 2.12.0-29.10.beta]
+        flavor: [release]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        with:
+          sdk: ${{ matrix.sdk }}
+
+      - name: Run hello world
+        run: |
+          echo "main() { print('hello world'); }" > hello.dart
+          dart hello.dart
+
+  test_raw:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         # Test latest stable, beta, dev, and main channels + last stable release
         # prior to the introduction of the unified `dart` developer tool.
         sdk: [stable, beta, dev, main, 2.9.3, 2.12.0-29.10.beta]
+        flavor: [raw]
     steps:
       - uses: actions/checkout@v2
       - uses: ./

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -35,7 +35,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         # Test latest stable, beta, dev, and main channels + last stable release
-        # prior to the introduction of the unified `dart` developer tool.
+        # prior to the introduction of the unified `dart` developer tool, using
+        # raw (unsigned) bits.
         sdk: [stable, beta, dev, main, 2.9.3, 2.12.0-29.10.beta]
         flavor: [raw]
     steps:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ The action takes the following inputs:
       Available channels are `stable`, `beta`, `dev`, and `main`. See
       https://dart.dev/tools/sdk/archive for details.
 
+  * `flavor`: Which build flavor to setup.
+    * Avaliable build flavors are `raw` and `release`.
+    * `release` flavor contains published builds.
+    * `raw` flavor contains unpublished builds, which can be used by developers
+      to test against SDK versions before a release.
+    * `main` release channel only supports `raw` build flavor.
+
   * `architecture`: The CPU architecture to setup support for. Valid options are
     `x64`, `ia32`, `arm`, and `arm64`. Note that not all CPU architectures are
     supported on all operating systems; see https://dart.dev/tools/sdk/archive
@@ -168,6 +175,9 @@ jobs:
 ```
 
 # Version history
+
+## v1.1
+  * Added a `flavor` option setup.sh to allow downloading unpublished builds.
 
 ## v1.0
   * Promoted to 1.0 stable.

--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,11 @@ inputs:
     description: "The CPU architecture ('x64', 'ia32', 'arm', or 'arm64')."
     required: false
     default: "x64"
+  flavor:
+    description: "The build flavor ('raw' or 'release')."
+    required: false
 runs:
   using: "composite"
   steps:
-    - run: $GITHUB_ACTION_PATH/setup.sh ${{ inputs.sdk }} ${{ runner.os }} ${{ inputs.architecture }}
+    - run: $GITHUB_ACTION_PATH/setup.sh ${{ inputs.sdk }} ${{ runner.os }} ${{ inputs.architecture }} ${{ inputs.flavor }}
       shell: bash

--- a/setup.sh
+++ b/setup.sh
@@ -41,7 +41,27 @@ fi
 OS="${2:-Linux}"
 ARCH="${3:-x64}"
 OS=$(echo "$OS" | awk '{print tolower($0)}')
-echo "Installing Dart SDK version \"${VERSION}\" from the ${CHANNEL} channel on ${OS}-${ARCH}"
+
+DEFAULT_FLAVOR=release
+if [[ $SDK == main ]]
+then
+  DEFAULT_FLAVOR=raw
+fi
+
+FLAVOR="${4:-$DEFAULT_FLAVOR}"
+if ! [[ $FLAVOR == raw || $FLAVOR == release ]]
+then
+  echo -e "::error::Unrecognized build flavor \"${FLAVOR}\"."
+  exit 1
+fi
+
+if [[ $SDK == main && $FLAVOR != raw ]]
+then
+  echo -e "::error::Main channel only supports raw build flavor."
+  exit 1
+fi
+
+echo "Installing Dart SDK version \"${VERSION}\" from the ${CHANNEL} channel (${FLAVOR}) on ${OS}-${ARCH}"
 
 # Calculate download Url. Based on:
 # https://dart.dev/tools/sdk/archive#download-urls
@@ -51,7 +71,7 @@ if [[ $SDK == main ]]
 then
   URL="${PREFIX}/be/raw/latest/${BUILD}"
 else
-  URL="${PREFIX}/${CHANNEL}/release/${VERSION}/${BUILD}"
+  URL="${PREFIX}/${CHANNEL}/${FLAVOR}/${VERSION}/${BUILD}"
 fi
 echo "Downloading ${URL}..."
 


### PR DESCRIPTION
This allows developers relying on SDK changes to land and test changes
in other packages using a raw dev build so we can validate changes,
publish them, and roll to dependent packages (such as flutter) faster.

Closes: https://github.com/dart-lang/setup-dart/issues/29