### PR TITLE
Support for downloading unsigned dev builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ The action takes the following inputs:
     supported on all operating systems; see https://dart.dev/tools/sdk/archive
     for valid combinations.
 
+  * `signed`: Whether to install signed SDK binaries (defaults to true).
+    Unsigned binaries may not work on all operating systems. This option is
+    exposed for core packages that need to test against unreleased dev SDKs that
+    are automatically rolled in to the flutter CI systems.
+
 ## Basic example
 
 Install the latest stable SDK, and run Hello World.
@@ -168,6 +173,9 @@ jobs:
 ```
 
 # Version history
+
+## v1.1
+  * Added support for installing unsigned dev SDKs.
 
 ## v1.0
   * Promoted to 1.0 stable.

--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,12 @@ inputs:
     description: "The CPU architecture ('x64', 'ia32', 'arm', or 'arm64')."
     required: false
     default: "x64"
+  signed:
+    description: "Whether to install a signed or unsigned Dart SDK build. Used to install unpublished dev releases."
+    required: false
+    default: true
 runs:
   using: "composite"
   steps:
-    - run: $GITHUB_ACTION_PATH/setup.sh ${{ inputs.sdk }} ${{ runner.os }} ${{ inputs.architecture }}
+    - run: $GITHUB_ACTION_PATH/setup.sh ${{ inputs.sdk }} ${{ runner.os }} ${{ inputs.architecture }} ${{inputs.signed }}
       shell: bash

--- a/setup.sh
+++ b/setup.sh
@@ -9,14 +9,15 @@
 # Bash script that downloads and does setup for a Dart SDK.                   #
 # Takes three params; first listed is the default:                            #
 # $1: Dart SDK version/channel: stable|beta|dev|main|<version_string>         #
-# $2: Dart channel (DEPRECATED): stable|beta|dev                              #
-# $3: OS: Linux|Windows|macOS                                                 #
-# $4: ARCH: x64|ia32                                                          #
+# $2: OS: Linux|Windows|macOS                                                 #
+# $3: ARCH: x64|ia32                                                          #
+# $4: SIGNED: true|false  (optional, defaults to true)                        #
 ###############################################################################
 
 # Parse SDK and version args.
 SDK="${1:-stable}"
 VERSION=
+SIGNED="${4:-true}"
 if [[ $SDK == stable || $SDK == beta || $SDK == dev || $SDK == main ]]
 then
   CHANNEL=$SDK
@@ -47,12 +48,14 @@ echo "Installing Dart SDK version \"${VERSION}\" from the ${CHANNEL} channel on 
 # https://dart.dev/tools/sdk/archive#download-urls
 PREFIX="https://storage.googleapis.com/dart-archive/channels"
 BUILD="sdk/dartsdk-${OS}-${ARCH}-release.zip"
-if [[ $SDK == main ]]
+CHANNEL_FOLDER="${CHANNEL/main/be}"
+if [[ $SIGNED == false || $SDK == main ]]
 then
-  URL="${PREFIX}/be/raw/latest/${BUILD}"
+  BINARIES_FOLDER=raw
 else
-  URL="${PREFIX}/${CHANNEL}/release/${VERSION}/${BUILD}"
+  BINARIES_FOLDER=release
 fi
+URL="${PREFIX}/${CHANNEL_FOLDER}/${BINARIES_FOLDER}/${VERSION}/${BUILD}"
 echo "Downloading ${URL}..."
 
 # Download installation zip.


### PR DESCRIPTION
Core packages, like `webdev/dwds`, need to run tests again dev candidate
releases that will be rolled into flutter.

This change allows users of the CI to specify whether they want to download
signed or unsigned builds. The former is what we properly call a release,
the latter is a build that is only available under the `raw` folder in our
cloud storage.

There are two other options here:
* default all dev builds to use unsigned builds. I'm not sure if this
  will break on non-linux systems, so we could do it only for linux for
  example.
* define a new name `dev_unsigned` and expose it as if it existed as a
  channel.  This would be desugared into a dev/raw request, similar to
  how the `main` name is desugared here.

@athomas - what's a good way to test things out? Should I try to update one of our repos to use my fork and see if that works out? Also, should I include the release notes here or should that be done separately?

Fixes #29

/cc @annagrin 