### PR TITLE
refactor the readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,46 @@
-Please see the [version history](https://github.com/dart-lang/setup-dart/blob/main/README.md#version-history) in the README.md file.
+## v1.4.0
+
+* Automatically create OIDC token for pub.dev.
+* Add a reusable workflow for publishing.
+
+## v1.3.0
+
+* The install location of the Dart SDK is now available
+  in an environment variable, `DART_HOME`
+  ([#43](https://github.com/dart-lang/setup-dart/issues/43)).
+* Fixed an issue where cached downloads could lead to unzip issues
+  on self-hosted runners
+  ([#35](https://github.com/dart-lang/setup-dart/issues/35)).
+
+## v1.2.0
+
+* Fixed a path issue impacting git dependencies on Windows.
+
+## v1.1.0
+
+* Added a `flavor` option setup.sh to allow downloading unpublished builds.
+
+## v1.0.0
+
+* Promoted to 1.0 stable.
+
+## v0.5
+
+* Fixed a Windows `pub global activate` path issue.
+
+## v0.4
+
+* Removed previously deprecated input `channel`. Use the `sdk` input instead.
+* Added support for specifying the CPU architecture.
+
+## v0.3
+
+* Added support for installing SDKs from the `main` channel.
+
+## v0.2
+
+* Added support for installing a specific SDK version (e.g. `2.10.0`).
+
+## v0.1
+
+* Initial version.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# How to Contribute
+## How to Contribute
 
 Prior to sending patches and contributions to this project, please file
 an issue in the issue tracker to ensure there is alignment with the overall

--- a/README.md
+++ b/README.md
@@ -10,7 +10,17 @@ and sets up of a Dart SDK for use in actions by:
   and [`pub` cache](https://dart.dev/tools/pub/cmd/pub-get#the-system-package-cache)
   to the system path
 
-# Usage
+## Usage
+
+Install the latest stable SDK and run 'Hello World':
+
+```yml
+steps:
+- uses: actions/checkout@v3
+- uses: dart-lang/setup-dart@v1
+- run: dart pub get
+- run: dart run bin/hello_world.dart
+```
 
 ## Inputs
 
@@ -23,47 +33,20 @@ The action takes the following inputs:
       See the [Dart SDK archive](https://dart.dev/get-dart/archive) for details.
 
   * `flavor`: Which build flavor to setup.
-    * Available build flavors are `raw` and `release`.
-    * `release` flavor contains published builds.
-    * `raw` flavor contains unpublished builds, which can be used by developers
-      to test against SDK versions before a release.
-    * `main` release channel only supports `raw` build flavor.
+    * The available build flavors are `release` and `raw`.
+    * The `release` flavor contains published builds.
+    * The `raw` flavor contains unpublished builds; these can be used by
+      developers to test against SDK versions before a release. Note that the 
+      `main` release channel only supports `raw` build flavor.
 
-  * `architecture`: The CPU architecture to setup support for. Valid options are
-    `x64`, `ia32`, `arm`, and `arm64`. Note that not all CPU architectures are
-    supported on all operating systems; see the 
-    [Dart system requirements](https://dart.dev/get-dart#system-requirements)
-    for valid combinations.
+  * `architecture`: The CPU architecture to setup support for.
+    * Valid options are `x64`, `ia32`, `arm`, and `arm64`.
+    * Note that not all CPU architectures are supported on all operating
+      systems; see the 
+      [Dart system requirements](https://dart.dev/get-dart#system-requirements)
+      for valid combinations.
 
-## Basic example
-
-Install the latest stable SDK, and run Hello World.
-
-```yml
-name: Dart
-
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-
-jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dart-lang/setup-dart@v1
-
-      - name: Install dependencies
-        run: dart pub get
-
-      - name: Hello world
-        run: dart run bin/hello_world.dart
-```
-
-## Check static analysis, formatting, and test example
+## Check static analysis, formatting, and run tests
 
 Various static checks:
 
@@ -127,7 +110,7 @@ jobs:
         run: dart test
 ```
 
-## Testing older Dart SDKs example
+## Testing older Dart SDKs
 
 The Dart SDK continuously evolves, and new features and tools are added. The Dart
 2.10 SDK introduced a new unified `dart` developer tool, which is what we use in
@@ -178,55 +161,14 @@ jobs:
         run: pub run test
 ```
 
-# Version history
+## License
 
-## v1.4
+See the [LICENSE](LICENSE) file.
 
-* Automatically create OIDC token for pub.dev.
-* Add a reusable workflow for publishing.
+## Contributing
 
-## v1.3
+Contributions are welcome! Please see [CONTRIBUTING.md.md](CONTRIBUTING.md.md).
 
-* The install location of the Dart SDK is now available
-  in an environment variable, `DART_HOME`
-  ([#43](https://github.com/dart-lang/setup-dart/issues/43)).
-* Fixed an issue where cached downloads could lead to unzip issues
-  on self-hosted runners
-  ([#35](https://github.com/dart-lang/setup-dart/issues/35)).
+## Version history
 
-## v1.2
-
-* Fixed a path issue impacting git dependencies on Windows.
-
-## v1.1
-
-* Added a `flavor` option setup.sh to allow downloading unpublished builds.
-
-## v1.0
-
-* Promoted to 1.0 stable.
-
-## v0.5
-
-* Fixed a Windows `pub global activate` path issue.
-
-## v0.4
-
-* Removed previously deprecated input `channel`. Use the `sdk` input instead.
-* Added support for specifying the CPU architecture.
-
-## v0.3
-
-* Added support for installing SDKs from the `main` channel.
-
-## v0.2
-
-* Added support for installing a specific SDK version (e.g. `2.10.0`).
-
-## v0.1
-
-* Initial version.
-
-# License
-
-See the [`LICENSE`](LICENSE) file.
+Please see out [CHANGELOG.md](CHANGELOG.md) file.


### PR DESCRIPTION
General refactoring of the readme:
- move the version history back into the changelog file (but keep a pointer to it from the readme); fix https://github.com/dart-lang/setup-dart/issues/70
- bump the hello world example to the top of the file
- some clarifications around raw and release flavors

@athomas, wrt the `raw` and `release` flavors. Isn't this something we can determine w/o an input arg? `stable`, `beta`, and `dev` channels would imply a release flavor, and the `main` channel would imply a `raw` flavor?
