### PR TITLE
refactor the CI + testing setup

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -93,7 +93,7 @@ jobs:
           dart hello.dart
 
   # Test inferring the channel from the sdk parameter.
-  test_arch:
+  test_inferred_channels:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -91,3 +91,23 @@ jobs:
         run: |
           echo "main() { print('hello world'); }" > hello.dart
           dart hello.dart
+
+  # Test inferring the channel from the sdk parameter.
+  test_arch:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        sdk: [2.12.0-29.10.beta]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./
+        with:
+          sdk: ${{ matrix.sdk }}
+          architecture: ia32
+
+      - name: Run hello world
+        run: |
+          echo "main() { print('hello world'); }" > hello.dart
+          dart hello.dart
+      - run: dart --version

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        sdk: [2.9.3, 2.12.0, stable, beta, dev]
+        sdk: [2.12.0, stable, beta, dev]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -34,13 +34,32 @@ jobs:
       - run: dart analyze
       - run: dart test
 
+  # Test older SDKs.
+  test_older:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        sdk: [2.9.3]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./
+        with:
+          sdk: ${{ matrix.sdk }}
+
+      - name: Run hello world
+        run: |
+          echo "main() { print('hello world'); }" > hello.dart
+          dart hello.dart
+
   # Test the raw flavor SDKs.
   test_raw:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        sdk: [2.9.3, 2.12.0, stable, beta, dev]
+        sdk: [2.12.0, stable, dev]
         flavor: [raw]
       fail-fast: false
     steps:
@@ -59,7 +78,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        sdk: [2.9.3, 2.12.0, stable, beta, dev]
+        sdk: [2.12.0, stable, dev]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        sdk: [2.12.0, stable, dev]
+        sdk: [dev, main]
         flavor: [raw]
       fail-fast: false
     steps:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -9,16 +9,18 @@ on:
   - cron: "0 0 * * 0" # Run every Sunday at 00:00.
 
 jobs:
+
+  # Default test configurations.
   test:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: example
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        # Test latest stable, beta, dev channels + last stable release
-        # prior to the introduction of the unified `dart` developer tool.
-        sdk: [stable, beta, dev, 2.9.3, 2.12.0-29.10.beta]
-        flavor: [release]
+        sdk: [2.9.3, 2.12.0, stable, beta, dev]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v3
       - uses: ./
@@ -26,25 +28,21 @@ jobs:
           sdk: ${{ matrix.sdk }}
 
       - name: Print DART_HOME
-        shell: bash
         run: echo "Dart SDK installed in $DART_HOME"
+      - run: dart pub get
+      - run: dart run bin/main.dart
+      - run: dart analyze
+      - run: dart test
 
-      - name: Run hello world
-        run: |
-          echo "main() { print('hello world'); }" > hello.dart
-          dart hello.dart
-
+  # Test the raw flavor SDKs.
   test_raw:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        # Test latest stable, beta, dev, and main channels + last stable release
-        # prior to the introduction of the unified `dart` developer tool, using
-        # raw (unsigned) bits.
-        sdk: [stable, beta, dev, main, 2.9.3, 2.12.0-29.10.beta]
+        sdk: [2.9.3, 2.12.0, stable, beta, dev]
         flavor: [raw]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v3
       - uses: ./
@@ -56,12 +54,13 @@ jobs:
           echo "main() { print('hello world'); }" > hello.dart
           dart hello.dart
 
+  # Test the architecture input parameter.
   test_arch:
     runs-on: windows-latest
     strategy:
-      fail-fast: false
       matrix:
-        sdk: [stable, beta, dev, 2.9.3, 2.12.0-29.10.beta]
+        sdk: [2.9.3, 2.12.0, stable, beta, dev]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v3
       - uses: ./
@@ -73,50 +72,3 @@ jobs:
         run: |
           echo "main() { print('hello world'); }" > hello.dart
           dart hello.dart
-          
-  test_pub:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        sdk: [stable, beta]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./
-        with:
-          sdk: ${{ matrix.sdk }}
-
-      - name: Global activate + run
-        run: |
-          dart pub global activate stagehand
-          mkdir testapp
-          cd testapp
-          stagehand console-simple
-          dart pub get
-          dart run
-
-  test_test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        # Test latest stable, beta, dev channels
-        sdk: [stable, beta, dev]
-        flavor: [release]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./
-        with:
-          sdk: ${{ matrix.sdk }}
-      
-      - id: dart_pub_upgrade
-        name: Dart pub upgrade
-        working-directory: example
-        run: dart pub upgrade
-        
-      - name: Dart test
-        if: "always() && steps.dart_pub_upgrade.conclusion == 'success'"
-        working-directory: example
-        run: dart test

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        sdk: [stable, beta, dev, 2.10.3, 2.12.0-29.10.beta]
+        sdk: [2.18.0, stable, beta, dev]
     steps:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,11 @@ branding:
   color: blue
 inputs:
   sdk:
-    description: "The channel, or a specific version from a channel to install ('stable', 'beta', 'dev', '2.7.2', '2.12.0-1.4.beta'). Using one of the three channels instead of a version will give you the latest version published to that channel."
+    description:
+      The channel, or a specific version from a channel to install ('stable',
+      'beta', 'dev', '2.7.2', '2.12.0-1.4.beta'). Using one of the three
+      channels instead of a version will give you the latest version published
+      to that channel.
     required: false
     default: "stable"
   architecture:

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ branding:
   color: blue
 inputs:
   sdk:
-    description:
+    description: >-
       The channel, or a specific version from a channel to install ('stable',
       'beta', 'dev', '2.7.2', '2.12.0-1.4.beta'). Using one of the three
       channels instead of a version will give you the latest version published

--- a/example/bin/main.dart
+++ b/example/bin/main.dart
@@ -1,0 +1,7 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+void main(List<String> args) {
+  print('hello world');
+}

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,11 +1,8 @@
 name: example
 publish_to: none
+
 environment:
   sdk: ">=2.12.0 <3.0.0"
-
-dependencies:
-  characters:
-    git: https://github.com/dart-lang/characters
 
 dev_dependencies:
   test: any


### PR DESCRIPTION
refactor the CI + testing setup:
- consolidate into fewer testing configs; one main config - `test` - and additional ones for the flavor and architecture params
- use the example/ project in this repo for more of the testing (instead of stagehand)
- fix https://github.com/dart-lang/setup-dart/issues/73
