### PR TITLE
set up a cron to build the action's javascript

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ name: Build
 on:
   pull_request:
     branches: [main]
+  schedule:
+    - cron: "0 0 * * 0" # Run every Sunday at 00:00.
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,4 +17,5 @@ jobs:
         with:
           sdk: dev
       - run: dart pub get
+      - run: dart analyze --fatal-infos
       - run: dart tool/sig.dart --verify


### PR DESCRIPTION
- set up a cron to build the action's javascript

We have weekly cron's to test the action but not to verify that we can build the action's javascript (from the latest `dev` sdk). This adds a cron for the build workflow (it'll help us catch things like https://github.com/dart-lang/setup-dart/issues/95 sooner).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
