### PR TITLE
Install a Flutter SDK in the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,13 +29,15 @@ jobs:
     steps:
       # Checkout repository
       - uses: actions/checkout@v4
-      # Setup Dart SDK with JWT token
+      # Set up the Dart SDK and provision the OIDC token used for publishing.
+      # The `dart` command from this step will be shadowed by the one from the
+      # Flutter SDK below. 
       - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
       # Download flutter SDK - needed for publishing Flutter packages. Can also
       # publish pure Dart packages.
       #
-      # This will add the flutter/bin/dart executable to path, that sets up
-      # FLUTTER_ROOT.
+      # The dart binary from a Flutter SDK facilitates publishing both Flutter
+      # and pure-dart packages.
       - uses: flutter-actions/setup-flutter@d030cb603380106494f72d65a7e52462f380781f
       # Minimal package setup and dry run checks.
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,12 @@ jobs:
       - uses: actions/checkout@v4
       # Setup Dart SDK with JWT token
       - uses: dart-lang/setup-dart@0a8a0fc875eb934c15d08629302413c671d3f672
+      # Download flutter SDK - needed for publishing Flutter packages. Can also
+      # publish pure Dart packages.
+      #
+      # This will add the flutter/bin/dart executable to path, that sets up
+      # FLUTTER_ROOT.
+      - uses: flutter-actions/setup-flutter@d030cb603380106494f72d65a7e52462f380781f
       # Minimal package setup and dry run checks.
       - name: Install dependencies
         run: dart pub get


### PR DESCRIPTION
Supposed to fix https://github.com/dart-lang/setup-dart/issues/68

Validated that the pub-get is able to resolve a flutter package in: https://github.com/sigurdm/private_repo2/actions/runs/11913212325/job/33198427010#step:6:109

Ideally we would have a flutter provided setup action, not a community provided one. But given that we can lock to a specific revision of the action I think this is still safe.

Ideally we only install the flutter sdk when needed, but with the frequency of publishing that is a very minor problem. 
