### PR TITLE
Update dart.yml due to discontinued platform

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -58,7 +58,7 @@ jobs:
 
   # Test the architecture input parameter.
   test_arch:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -58,7 +58,9 @@ jobs:
 
   # Test the architecture input parameter.
   test_arch:
-    runs-on: ubuntu-latest
+    # there is no 'ubuntu-arm-latest' runner, so pinning to 24.04: 
+    # https://github.com/orgs/community/discussions/148648#discussioncomment-11858187
+    runs-on: ubuntu-24.04-arm 
     steps:
       - uses: actions/checkout@v4
       - uses: ./

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./
         with:
-          architecture: ia32
+          architecture: arm64
 
       - name: Run hello world
         run: |

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -86,7 +86,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./
         with:
-          architecture: arm64
+          architecture: ${{ matrix.arch }}
+          sdk: ${{ matrix.sdk }}
 
       - name: Run hello world
         run: |

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -58,9 +58,30 @@ jobs:
 
   # Test the architecture input parameter.
   test_arch:
-    # there is no 'ubuntu-arm-latest' runner, so pinning to 24.04: 
-    # https://github.com/orgs/community/discussions/148648#discussioncomment-11858187
-    runs-on: ubuntu-24.04-arm 
+    strategy:
+      fail-fast: false
+      matrix:
+        # Available runners in public repos:
+        # https://docs.github.com/en/actions/how-tos/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+        include:
+          # The default MacOS tests above use x64; here we cover arm64.
+          - os: macos-latest
+            arch: arm64
+            sdk: dev
+          - os: macos-latest
+            arch: arm64
+            sdk: stable
+          # The default linux tests above use x64; here we cover arm64. 
+          # There is no 'ubuntu-arm-latest' runner, so we're pinning to 24.04: 
+          # https://github.com/orgs/community/discussions/148648#discussioncomment-11858187
+          - os: ubuntu-24.04-arm
+            arch: arm64
+            sdk: dev
+          - os: ubuntu-24.04-arm
+            arch: arm64
+            sdk: stable
+
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./


### PR DESCRIPTION
Update the architecture passed in the `test_arch` test to not rely on ia32, which was recently removed: 
https://github.com/dart-lang/sdk/issues/49969#issuecomment-2891764170

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
